### PR TITLE
MARKETINFRA-5838 AsyncLoadingCache initialization fixed

### DIFF
--- a/src/main/java/ru/yandex/market/graphouse/search/MetricSearch.java
+++ b/src/main/java/ru/yandex/market/graphouse/search/MetricSearch.java
@@ -157,7 +157,6 @@ public class MetricSearch implements InitializingBean, Runnable {
 
         dirContentProvider = Caffeine.newBuilder()
             .expireAfterAccess(dirContentCacheTimeMinutes, TimeUnit.MINUTES)
-            .softValues()
             .recordStats()
             .buildAsync((dir) -> dirContentBatcher.loadDirContent(dir));
 


### PR DESCRIPTION
Caused by: java.lang.IllegalStateException: Weak or soft values can not be combined with AsyncLoadingCache
	at com.github.benmanes.caffeine.cache.Caffeine.requireState(Caffeine.java:200) ~[caffeine-2.8.2.jar:?]