### PR TITLE
Using Hikari connection pool for MetricSearch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     compile 'org.eclipse.jetty:jetty-server:9.2.10.v20150310'
     compile 'org.eclipse.jetty:jetty-servlet:9.2.10.v20150310'
     compile 'com.beust:jcommander:1.60'
+    compile 'com.zaxxer:HikariCP:3.4.5'
 
     testCompile group: 'junit', name: 'junit', version: '4.8.1'
     testCompile 'org.mockito:mockito-core:2.28.2'

--- a/src/main/java/ru/yandex/market/graphouse/config/MetricsConfig.java
+++ b/src/main/java/ru/yandex/market/graphouse/config/MetricsConfig.java
@@ -37,6 +37,9 @@ public class MetricsConfig {
     private JdbcTemplate clickHouseJdbcTemplate;
 
     @Autowired
+    private JdbcTemplate clickHouseJdbcTemplateSearch;
+
+    @Autowired
     private StatisticsService statisticsService;
 
     @Value("${graphouse.clickhouse.data-table}")
@@ -63,7 +66,7 @@ public class MetricsConfig {
     @Bean
     public MetricSearch metricSearch() {
         return new MetricSearch(
-            clickHouseJdbcTemplate, monitoring, ping,
+            clickHouseJdbcTemplateSearch, monitoring, ping,
             metricValidator(), retentionProvider(), statisticsService
         );
     }

--- a/src/main/resources/graphouse-default.properties
+++ b/src/main/resources/graphouse-default.properties
@@ -47,6 +47,11 @@ graphouse.http.max-form-context-size-bytes=500000
 graphouse.http.response-buffer-size-bytes=32768
 
 #Metric search and tree
+graphouse.tree.clickhouse.pool.max-life-time-seconds=60
+graphouse.tree.clickhouse.pool.max-pool-size=15
+graphouse.tree.clickhouse.pool.minimum-idle=0
+graphouse.tree.clickhouse.pool.validation-timeout-seconds=60
+
 graphouse.search.refresh-seconds=60
 graphouse.tree.in-memory-levels=3
 graphouse.tree.dir-content.cache-time-minutes=60

--- a/src/test/java/ru/yandex/market/graphouse/config/DbConfigTest.java
+++ b/src/test/java/ru/yandex/market/graphouse/config/DbConfigTest.java
@@ -1,5 +1,6 @@
 package ru.yandex.market.graphouse.config;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.Assert;
 import org.junit.Test;
 import ru.yandex.clickhouse.BalancedClickhouseDataSource;
@@ -33,5 +34,20 @@ public class DbConfigTest {
         Assert.assertTrue(ds instanceof BalancedClickhouseDataSource);
         BalancedClickhouseDataSource cds = (BalancedClickhouseDataSource) ds;
         Assert.assertEquals(Arrays.asList("jdbc:clickhouse://host1:42/db", "jdbc:clickhouse://host2:42/db"), cds.getAllClickhouseUrls());
+    }
+
+    @Test
+    public void clickHouseSearchDataSource() {
+        DbConfig dbConfig = new DbConfig();
+        DataSource hds = dbConfig.clickHouseSearchDataSource(
+            "host1", 42, "db", 60, 10, 0, 60, -1, new ClickHouseProperties(), null, null
+        );
+        Assert.assertTrue(hds instanceof HikariDataSource);
+        DataSource ds = ((HikariDataSource) hds).getDataSource();
+        Assert.assertTrue(ds instanceof ClickHouseDataSource);
+        ClickHouseDataSource cds = (ClickHouseDataSource) ds;
+        Assert.assertEquals("host1", cds.getHost());
+        Assert.assertEquals("db", cds.getDatabase());
+        Assert.assertEquals(42, cds.getPort());
     }
 }


### PR DESCRIPTION
MetricSearch make a lot of requests to clickhouse, especially when the Graphouse is starting. Connections reusings will decrease query execution time.