### PR TITLE
Handle for searching cached metric

### DIFF
--- a/src/main/java/ru/yandex/market/graphouse/GraphouseWebServer.java
+++ b/src/main/java/ru/yandex/market/graphouse/GraphouseWebServer.java
@@ -71,6 +71,7 @@ public class GraphouseWebServer {
         context.addServlet(metricSearchServletHolder, "/multiApprove/*");
         context.addServlet(metricSearchServletHolder, "/hide/*");
         context.addServlet(metricSearchServletHolder, "/multiHide/*");
+        context.addServlet(metricSearchServletHolder, "/searchCachedMetrics/*");
 
         ServletHolder monitoringServletHolder = new ServletHolder(monitoringServlet);
         context.addServlet(monitoringServletHolder, "/ping");

--- a/src/main/java/ru/yandex/market/graphouse/search/MetricSearch.java
+++ b/src/main/java/ru/yandex/market/graphouse/search/MetricSearch.java
@@ -30,6 +30,7 @@ import ru.yandex.market.graphouse.statistics.StatisticsService;
 import ru.yandex.market.graphouse.utils.AppendableList;
 import ru.yandex.market.graphouse.utils.AppendableResult;
 import ru.yandex.market.graphouse.utils.AppendableWrapper;
+import ru.yandex.market.graphouse.utils.TraceAppendableWrapper;
 
 import java.io.IOException;
 import java.sql.PreparedStatement;
@@ -558,6 +559,10 @@ public class MetricSearch implements InitializingBean, Runnable {
 
     public void search(String query, Appendable result) throws IOException {
         metricTree.search(query, new AppendableWrapper(result));
+    }
+
+    public void searchCachedMetrics(String query, Appendable result, boolean writeLoadedInfo) throws IOException {
+        metricTree.searchCachedMetrics(query, new TraceAppendableWrapper(result, writeLoadedInfo));
     }
 
     public void search(String query, AppendableResult result) throws IOException {

--- a/src/main/java/ru/yandex/market/graphouse/search/MetricSearchServlet.java
+++ b/src/main/java/ru/yandex/market/graphouse/search/MetricSearchServlet.java
@@ -58,6 +58,9 @@ public class MetricSearchServlet extends HttpServlet {
             case "/multiHide":
                 multiModify(req, resp, MetricStatus.HIDDEN);
                 break;
+            case "/searchCachedMetrics":
+                searchCachedMetrics(req, resp);
+                break;
             default:
                 badRequest(resp);
                 break;
@@ -143,5 +146,28 @@ public class MetricSearchServlet extends HttpServlet {
         }
 
         metricSearch.search(query, writer);
+    }
+
+    private void searchCachedMetrics(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String query = req.getParameter("query");
+        final PrintWriter writer = resp.getWriter();
+
+        if (query == null || query.isEmpty()) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            writer.println(
+                "Usage:\n" +
+                    "GET /searchCachedMetrics?query=<search_query>\n" +
+                    "GET /searchCachedMetrics?query=<search_query>&writeLoadedInfo=true\n"
+            );
+            return;
+        }
+
+        String writeLoadedInfoParam = req.getParameter("writeLoadedInfo");
+        boolean writeLoadedInfo = false;
+        if (writeLoadedInfoParam != null && !writeLoadedInfoParam.isEmpty()) {
+            writeLoadedInfo = Boolean.parseBoolean(writeLoadedInfoParam);
+        }
+
+        metricSearch.searchCachedMetrics(query, writer, writeLoadedInfo);
     }
 }

--- a/src/main/java/ru/yandex/market/graphouse/search/MetricSearchServlet.java
+++ b/src/main/java/ru/yandex/market/graphouse/search/MetricSearchServlet.java
@@ -105,6 +105,7 @@ public class MetricSearchServlet extends HttpServlet {
         resp.getOutputStream().println("GET  /multiApprove?query=<pattern>");
         resp.getOutputStream().println("GET  /hide?name=<metric>");
         resp.getOutputStream().println("GET  /multiHide?query=<pattern>");
+        resp.getOutputStream().println("GET  /searchCachedMetrics?query=<pattern>");
     }
 
     private void modify(HttpServletRequest req, HttpServletResponse resp, MetricStatus status) throws IOException {

--- a/src/main/java/ru/yandex/market/graphouse/search/tree/InMemoryMetricDir.java
+++ b/src/main/java/ru/yandex/market/graphouse/search/tree/InMemoryMetricDir.java
@@ -44,7 +44,7 @@ public class InMemoryMetricDir extends MetricDir {
 
     @Override
     public MetricName maybeGetMetric(String name) {
-        if (metrics == null){
+        if (metrics == null) {
             return null;
         }
         return metrics.get(name);
@@ -57,9 +57,19 @@ public class InMemoryMetricDir extends MetricDir {
     }
 
     @Override
+    public Map<String, MetricName> maybeGetMetrics() {
+        return getMetrics();
+    }
+
+    @Override
     public Map<String, MetricDir> getDirs() {
         initDirs();
         return dirs;
+    }
+
+    @Override
+    public Map<String, MetricDir> maybeGetDirs() {
+        return getDirs();
     }
 
     public boolean hasDirs() {

--- a/src/main/java/ru/yandex/market/graphouse/search/tree/LoadableMetricDir.java
+++ b/src/main/java/ru/yandex/market/graphouse/search/tree/LoadableMetricDir.java
@@ -44,8 +44,18 @@ public class LoadableMetricDir extends MetricDir {
     }
 
     @Override
+    public Map<String, MetricDir> maybeGetDirs() {
+        return getContentOrEmpty().getDirs();
+    }
+
+    @Override
     public Map<String, MetricName> getMetrics() {
         return getContent().getMetrics();
+    }
+
+    @Override
+    public Map<String, MetricName> maybeGetMetrics() {
+        return getContentOrEmpty().getMetrics();
     }
 
     @Override

--- a/src/main/java/ru/yandex/market/graphouse/search/tree/MetricDir.java
+++ b/src/main/java/ru/yandex/market/graphouse/search/tree/MetricDir.java
@@ -35,9 +35,13 @@ public abstract class MetricDir extends MetricBase {
         return parent.isRoot() ? dirName : parent.toString() + dirName;
     }
 
+    public abstract Map<String, MetricDir> maybeGetDirs();
+
     public abstract Map<String, MetricDir> getDirs();
 
     public abstract Map<String, MetricName> getMetrics();
+
+    public abstract Map<String, MetricName> maybeGetMetrics();
 
     public abstract boolean hasDirs();
 

--- a/src/main/java/ru/yandex/market/graphouse/utils/TraceAppendableWrapper.java
+++ b/src/main/java/ru/yandex/market/graphouse/utils/TraceAppendableWrapper.java
@@ -1,0 +1,52 @@
+package ru.yandex.market.graphouse.utils;
+
+import ru.yandex.market.graphouse.search.tree.InMemoryMetricDir;
+import ru.yandex.market.graphouse.search.tree.MetricDescription;
+import ru.yandex.market.graphouse.search.tree.MetricDir;
+
+import java.io.IOException;
+
+/**
+ * @author Mishunin Andrei <a href="mailto:mishunin@yandex-team.ru"></a>
+ * @date 14.12.2020
+ */
+public class TraceAppendableWrapper implements AppendableResult {
+    private final Appendable writer;
+    private final boolean writeLoadedInfo;
+
+    public TraceAppendableWrapper(Appendable writer, boolean writeLoadedInfo) {
+        this.writer = writer;
+        this.writeLoadedInfo = writeLoadedInfo;
+    }
+
+    @Override
+    public void appendMetric(MetricDescription metric) throws IOException {
+        writer.append(metric.getName())
+            .append(" type:")
+            .append(getMetricType(metric))
+            .append(", status:")
+            .append(metric.getStatus().name());
+
+        if (writeLoadedInfo && metric instanceof MetricDir) {
+            appendLoadedInfo((MetricDir) metric);
+        }
+
+        writer.append("\n");
+    }
+
+    @Override
+    public String toString() {
+        return writer.toString();
+    }
+
+    private String getMetricType(MetricDescription metric) {
+        return metric instanceof InMemoryMetricDir ? "IN_MEMORY" : "LOADABLE";
+    }
+
+    private void appendLoadedInfo(MetricDir dir) throws IOException {
+        writer.append(", loaded dirs: ")
+            .append(Integer.toString(dir.loadedDirCount()))
+            .append(", loaded metrics: ")
+            .append(Integer.toString(dir.loadedMetricCount()));
+    }
+}


### PR DESCRIPTION
New  handle `/searchCachedMetrics` for displaying the status of cached metrics