### PR TITLE
Updating log4j to 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,21 +22,23 @@ compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
-
+def log4jVersion = '2.15.0'
+def jettyVersion = '9.2.10.v20150310'
+def springVersion = '4.1.6.RELEASE'
 
 dependencies {
     compile 'ru.yandex.clickhouse:clickhouse-jdbc:0.1.50'
     compile 'com.google.guava:guava:21.0'
     compile 'com.github.ben-manes.caffeine:caffeine:2.8.2'
     compile 'com.google.code.gson:gson:2.3.1'
-    compile 'org.springframework:spring-jdbc:4.1.6.RELEASE'
-    compile 'org.springframework:spring-context:4.1.6.RELEASE'
-    compile 'org.apache.logging.log4j:log4j-api:2.14.0'
-    compile 'org.apache.logging.log4j:log4j-core:2.14.0'
-    compile 'org.apache.logging.log4j:log4j-web:2.14.0'
+    compile "org.springframework:spring-jdbc:$springVersion"
+    compile "org.springframework:spring-context:$springVersion"
+    compile "org.apache.logging.log4j:log4j-api:$log4jVersion"
+    compile "org.apache.logging.log4j:log4j-core:$log4jVersion"
+    compile "org.apache.logging.log4j:log4j-web:$log4jVersion"
     compile 'commons-dbcp:commons-dbcp:1.4'
-    compile 'org.eclipse.jetty:jetty-server:9.2.10.v20150310'
-    compile 'org.eclipse.jetty:jetty-servlet:9.2.10.v20150310'
+    compile "org.eclipse.jetty:jetty-server:$jettyVersion"
+    compile "org.eclipse.jetty:jetty-servlet:$jettyVersion"
     compile 'com.beust:jcommander:1.60'
     compile 'com.zaxxer:HikariCP:3.4.5'
 


### PR DESCRIPTION
Security Update. More details in: [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228)